### PR TITLE
feat: add admin dashboard

### DIFF
--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -41,14 +41,24 @@
               <span>My Images</span>
             </router-link>
             
-            <router-link 
-              v-if="authStore.isAuthenticated" 
-              to="/albums" 
-              class="nav-link" 
+            <router-link
+              v-if="authStore.isAuthenticated"
+              to="/albums"
+              class="nav-link"
               active-class="active"
             >
               <i class="fas fa-folder"></i>
               <span>Albums</span>
+            </router-link>
+
+            <router-link
+              v-if="authStore.isAuthenticated && authStore.hasRole('admin')"
+              to="/admin"
+              class="nav-link"
+              active-class="active"
+            >
+              <i class="fas fa-user-shield"></i>
+              <span>Admin</span>
             </router-link>
           </nav>
 
@@ -251,14 +261,24 @@
           <span>My Images</span>
         </router-link>
         
-        <router-link 
-          v-if="authStore.isAuthenticated" 
-          to="/albums" 
-          class="mobile-nav-link" 
+        <router-link
+          v-if="authStore.isAuthenticated"
+          to="/albums"
+          class="mobile-nav-link"
           @click="closeMobileMenu"
         >
           <i class="fas fa-folder"></i>
           <span>Albums</span>
+        </router-link>
+
+        <router-link
+          v-if="authStore.isAuthenticated && authStore.hasRole('admin')"
+          to="/admin"
+          class="mobile-nav-link"
+          @click="closeMobileMenu"
+        >
+          <i class="fas fa-user-shield"></i>
+          <span>Admin</span>
         </router-link>
         
         <router-link 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,9 @@ const AlbumCreate = () => import('./views/AlbumCreate.vue')
 import AlbumGallery from './views/AlbumGallery.vue'
 import UserProfile from './views/UserProfile.vue'
 import Home from './views/Home.vue'
+const AdminDashboard = () => import('./views/AdminDashboard.vue')
+const AdminUserDetail = () => import('./views/AdminUserDetail.vue')
+import { useAuthStore } from './stores/auth.js'
 
 // Create router
 const router = createRouter({
@@ -31,6 +34,8 @@ const router = createRouter({
     { path: '/albums/create', component: AlbumCreate, name: 'album-create' },
     { path: '/albums', component: AlbumGallery, name: 'albums' },
     { path: '/user/:username', component: UserProfile, name: 'user-profile' },
+    { path: '/admin', component: AdminDashboard, name: 'admin-dashboard', meta: { requiresAdmin: true } },
+    { path: '/admin/users/:id', component: AdminUserDetail, name: 'admin-user-detail', meta: { requiresAdmin: true } },
     // Add missing routes to fix Vue Router warnings
     { path: '/notifications', component: () => import('./views/Notifications.vue'), name: 'notifications' },
     { path: '/settings', component: () => import('./views/Settings.vue'), name: 'settings' },
@@ -45,6 +50,18 @@ const router = createRouter({
 
 // Create Pinia store
 const pinia = createPinia()
+
+// Navigation guard for admin routes
+router.beforeEach(async (to, from, next) => {
+  const authStore = useAuthStore(pinia)
+  if (!authStore.isInitialized) {
+    await authStore.initializeAuth()
+  }
+  if (to.meta.requiresAdmin && (!authStore.isAuthenticated || !authStore.hasRole('admin'))) {
+    return next({ name: 'dashboard' })
+  }
+  next()
+})
 
 // Create and mount app
 const app = createApp(App)

--- a/frontend/src/services/AdminService.js
+++ b/frontend/src/services/AdminService.js
@@ -1,0 +1,24 @@
+import apiService from './ApiService.js'
+
+/**
+ * Admin Service
+ * Provides admin-specific API calls
+ */
+export default {
+  /**
+   * Get list of users with statistics
+   * @returns {Promise<Array>}
+   */
+  async getUsers() {
+    return await apiService.get('/api/admin/users')
+  },
+
+  /**
+   * Get detailed user data including images and albums
+   * @param {number|string} id
+   * @returns {Promise<Object>}
+   */
+  async getUser(id) {
+    return await apiService.get(`/api/admin/users/${id}`)
+  }
+}

--- a/frontend/src/views/AdminDashboard.vue
+++ b/frontend/src/views/AdminDashboard.vue
@@ -1,0 +1,64 @@
+<template>
+  <AppLayout>
+    <div class="admin-dashboard container">
+      <h1>Admin Dashboard</h1>
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Images</th>
+            <th>Albums</th>
+            <th>Shared Images</th>
+            <th>Shared Albums</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="user in users" :key="user.id">
+            <td>
+              <router-link :to="{ name: 'admin-user-detail', params: { id: user.id } }">
+                {{ user.username }}
+              </router-link>
+            </td>
+            <td>{{ user.stats?.total_images || 0 }}</td>
+            <td>{{ user.stats?.total_albums || 0 }}</td>
+            <td>{{ user.stats?.shared_images || 0 }}</td>
+            <td>{{ user.stats?.shared_albums || 0 }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </AppLayout>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import AppLayout from '../components/AppLayout.vue'
+import adminService from '../services/AdminService.js'
+
+const users = ref([])
+
+onMounted(async () => {
+  try {
+    users.value = await adminService.getUsers()
+  } catch (e) {
+    console.error('Failed to load users', e)
+  }
+})
+</script>
+
+<style scoped>
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem;
+  border: 1px solid var(--border-light);
+  text-align: left;
+}
+.admin-table th {
+  background: var(--bg-secondary);
+}
+</style>

--- a/frontend/src/views/AdminUserDetail.vue
+++ b/frontend/src/views/AdminUserDetail.vue
@@ -1,0 +1,75 @@
+<template>
+  <AppLayout>
+    <div class="admin-user-detail container" v-if="user">
+      <h1>User: {{ user.username }}</h1>
+      <div class="tabs">
+        <button :class="{ active: activeTab === 'profile' }" @click="activeTab = 'profile'">Profile</button>
+        <button :class="{ active: activeTab === 'images' }" @click="activeTab = 'images'">Images</button>
+        <button :class="{ active: activeTab === 'albums' }" @click="activeTab = 'albums'">Albums</button>
+      </div>
+
+      <div v-if="activeTab === 'profile'" class="tab-content">
+        <p><strong>Email:</strong> {{ user.email }}</p>
+        <p><strong>Roles:</strong> {{ user.roles?.join(', ') }}</p>
+      </div>
+
+      <div v-if="activeTab === 'images'" class="tab-content">
+        <ul>
+          <li v-for="image in images" :key="image.id">{{ image.title || image.id }}</li>
+        </ul>
+      </div>
+
+      <div v-if="activeTab === 'albums'" class="tab-content">
+        <ul>
+          <li v-for="album in albums" :key="album.id">{{ album.title || album.id }}</li>
+        </ul>
+      </div>
+    </div>
+  </AppLayout>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import AppLayout from '../components/AppLayout.vue'
+import adminService from '../services/AdminService.js'
+
+const route = useRoute()
+const user = ref(null)
+const images = ref([])
+const albums = ref([])
+const activeTab = ref('profile')
+
+onMounted(async () => {
+  try {
+    const data = await adminService.getUser(route.params.id)
+    user.value = data.user || data
+    images.value = data.images || []
+    albums.value = data.albums || []
+  } catch (e) {
+    console.error('Failed to load user details', e)
+  }
+})
+</script>
+
+<style scoped>
+.tabs {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+.tabs button {
+  padding: 0.5rem 1rem;
+  background: var(--bg-secondary);
+  border: none;
+  cursor: pointer;
+}
+.tabs button.active {
+  background: var(--primary-color);
+  color: #fff;
+}
+.tab-content ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+</style>

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/admin')]
+class AdminController extends AbstractController
+{
+    public function __construct(private EntityManagerInterface $entityManager) {}
+
+    /**
+     * Authenticate user from Bearer token and ensure admin role
+     */
+    private function authenticateAdmin(Request $request): ?User
+    {
+        $authHeader = $request->headers->get('Authorization');
+        if (!$authHeader || !str_starts_with($authHeader, 'Bearer ')) {
+            return null;
+        }
+        $token = substr($authHeader, 7);
+        $user = $this->entityManager->getRepository(User::class)
+            ->findOneBy(['apiToken' => $token]);
+        if (!$user || !in_array('ROLE_ADMIN', $user->getRoles())) {
+            return null;
+        }
+        return $user;
+    }
+
+    #[Route('/users', name: 'admin_users', methods: ['GET', 'OPTIONS'])]
+    public function listUsers(Request $request, UserRepository $userRepository): JsonResponse
+    {
+        if ($request->getMethod() === 'OPTIONS') {
+            return new JsonResponse();
+        }
+        $admin = $this->authenticateAdmin($request);
+        if (!$admin) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Admin authentication required'
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+        $users = $userRepository->findAllWithStats();
+        $data = array_map(function($row) {
+            /** @var User $u */
+            $u = $row[0];
+            return [
+                'id' => $u->getId(),
+                'username' => $u->getUsername(),
+                'email' => $u->getEmail(),
+                'roles' => $u->getRoles(),
+                'stats' => [
+                    'total_images' => (int)$row['total_images'],
+                    'total_albums' => (int)$row['total_albums'],
+                    'shared_images' => (int)$row['shared_images'],
+                    'shared_albums' => (int)$row['shared_albums'],
+                ]
+            ];
+        }, $users);
+        return $this->json($data);
+    }
+
+    #[Route('/users/{id}', name: 'admin_user_detail', methods: ['GET', 'OPTIONS'])]
+    public function getUserDetail(int $id, Request $request, UserRepository $userRepository): JsonResponse
+    {
+        if ($request->getMethod() === 'OPTIONS') {
+            return new JsonResponse();
+        }
+        $admin = $this->authenticateAdmin($request);
+        if (!$admin) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Admin authentication required'
+            ], Response::HTTP_UNAUTHORIZED);
+        }
+        $user = $userRepository->find($id);
+        if (!$user) {
+            return $this->json([
+                'success' => false,
+                'error' => 'User not found'
+            ], Response::HTTP_NOT_FOUND);
+        }
+        $images = array_map(function($image) {
+            return [
+                'id' => $image->getId(),
+                'title' => $image->getTitle(),
+                'imageName' => $image->getImageName(),
+            ];
+        }, $user->getImages()->toArray());
+        $albums = array_map(function($album) {
+            return [
+                'id' => $album->getId(),
+                'name' => $album->getName(),
+            ];
+        }, $user->getAlbums()->toArray());
+        return $this->json([
+            'user' => [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'roles' => $user->getRoles(),
+            ],
+            'images' => $images,
+            'albums' => $albums,
+        ]);
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -106,4 +106,28 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Fetch all users with aggregated statistics
+     *
+     * Returns each user along with counts of their images, albums,
+     * and how many images/albums they have shared.
+     *
+     * @return array<array{0: User, total_images: string, total_albums: string, shared_images: string, shared_albums: string}>
+     */
+    public function findAllWithStats(): array
+    {
+        return $this->createQueryBuilder('u')
+            ->select('u')
+            ->addSelect('COUNT(DISTINCT i.id) AS total_images')
+            ->addSelect('COUNT(DISTINCT a.id) AS total_albums')
+            ->addSelect('SUM(CASE WHEN s.image IS NOT NULL THEN 1 ELSE 0 END) AS shared_images')
+            ->addSelect('SUM(CASE WHEN s.album IS NOT NULL THEN 1 ELSE 0 END) AS shared_albums')
+            ->leftJoin('u.images', 'i')
+            ->leftJoin('u.albums', 'a')
+            ->leftJoin('u.sharedItems', 's')
+            ->groupBy('u.id')
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
## Summary
- add service, views and routing for new admin dashboard
- protect admin routes via navigation guard
- expose admin-only navigation links
- add backend APIs for admin user listing and details

## Testing
- `php bin/phpunit` *(fails: Cannot assign null to property App\Entity\UserProfile::$userId of type int)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b41948ec908332a3e1970a674e65eb